### PR TITLE
Cap implausible max_speed_kph at ingest, switch drilldown PB to P95

### DIFF
--- a/DE/backend/app/pipeline/ingest.py
+++ b/DE/backend/app/pipeline/ingest.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Dict, List
 
 import pandas as pd
 
+log = logging.getLogger(__name__)
+
 ROOT_DIR = Path(__file__).resolve().parents[1]
 DEFAULT_INPUT_PATH = ROOT_DIR / "data" / "raw" / "sample_data.csv"
+
+# Anything above this is treated as a GPS spike, not a real top speed.
+# Reference: elite male sprinters peak ~36 km/h; Bolt's 100m peak was ~44 km/h.
+# College/club athletes regularly logging >36 km/h is almost always a tracker artifact.
+MAX_PLAUSIBLE_SPEED_KPH = 36.0
 
 REQUIRED_COLUMNS: List[str] = [
 	"athlete_number",
@@ -86,6 +94,20 @@ def _clean_strings(df: pd.DataFrame) -> pd.DataFrame:
 	return df
 
 
+def _cap_implausible_speeds(df: pd.DataFrame) -> pd.DataFrame:
+	"""Null out max_speed_kph (and the derived %-of-max) when the reading is
+	above human-plausible. Keeps the row's other metrics intact so distance,
+	load, accel, etc. still contribute to the cohort.
+	"""
+	mask = df["max_speed_kph"] > MAX_PLAUSIBLE_SPEED_KPH
+	n = int(mask.sum())
+	if n:
+		df.loc[mask, "max_speed_kph"] = pd.NA
+		df.loc[mask, "percentage_max_speed_kph"] = pd.NA
+		log.info("ingest: capped %d row(s) with max_speed_kph > %.1f", n, MAX_PLAUSIBLE_SPEED_KPH)
+	return df
+
+
 def ingest_data(input_path: str | Path = DEFAULT_INPUT_PATH) -> pd.DataFrame:
 	"""Read raw athlete session data and return a cleaned, schema-validated dataframe."""
 	path = Path(input_path)
@@ -97,7 +119,10 @@ def ingest_data(input_path: str | Path = DEFAULT_INPUT_PATH) -> pd.DataFrame:
 	cleaned_df = _coerce_numeric_columns(cleaned_df)
 	cleaned_df = _clean_strings(cleaned_df)
 
+	# dropna first (legit-missing rows go), then cap implausible speeds —
+	# capping AFTER dropna so flagged rows survive with just the speed nulled.
 	cleaned_df = cleaned_df.dropna(subset=REQUIRED_COLUMNS)
+	cleaned_df = _cap_implausible_speeds(cleaned_df)
 	cleaned_df = cleaned_df.drop_duplicates().reset_index(drop=True)
 
 	return cleaned_df

--- a/DE/backend/app/routes/athlete.py
+++ b/DE/backend/app/routes/athlete.py
@@ -170,6 +170,7 @@ def athlete_detail(
                     "avg": round(float(col.mean()), 2),
                     "max": round(float(col.max()), 2),
                     "min": round(float(col.min()), 2),
+                    "p95": round(float(col.quantile(0.95)), 2),
                 }
 
     from app.pipeline.metrics import RANK_COL_MAP

--- a/DE/frontend/components/athlete/athlete-drilldown-panel.tsx
+++ b/DE/frontend/components/athlete/athlete-drilldown-panel.tsx
@@ -51,7 +51,8 @@ export function AthleteDrilldownPanel({
 
   const s = detail.stats;
   const totalDistance = s.total_distance_m?.max ?? 0;
-  const maxSpeed      = s.max_speed_kph?.max   ?? 0;
+  // P95 across this athlete's sessions — robust to single-session GPS spikes.
+  const maxSpeed      = s.max_speed_kph?.p95   ?? 0;
   const sessionLoad   = s.session_load?.avg    ?? 0;
 
   return (
@@ -142,7 +143,7 @@ export function AthleteDrilldownPanel({
               label="Max Speed"
               value={maxSpeed.toFixed(1)}
               unit=" km/h"
-              caption="PB · Session Date"
+              caption="Peak (P95) across sessions"
               pctBadge={p.max_speed_perc_rank}
             />
             <DrillKpi

--- a/DE/frontend/lib/api.ts
+++ b/DE/frontend/lib/api.ts
@@ -119,7 +119,7 @@ export type AthleteRow = {
 
 export type AthleteDetail = AthleteRow & {
   session_count: number;
-  stats: Record<string, { avg: number; max: number; min: number }>;
+  stats: Record<string, { avg: number; max: number; min: number; p95: number }>;
   percentiles: Record<string, number>;
   timeline: Array<Record<string, number | null>>;
 };


### PR DESCRIPTION
Drilldown was showing GPS-spike artifacts (e.g. 42.2 km/h) as personal best. Adds a 36.0 km/h plausibility cap in the ingest pipeline that nulls max_speed_kph (and the derived %-of-max) on offending rows while keeping the rest of the row's metrics intact. Drilldown KPI now reads P95 across the athlete's sessions instead of .max(), so a single clean spike doesn't dominate the headline number.

Local smoke test: caps 1-2% of rows across sample + synthetic CSVs, post- ingest max <= 35.91 km/h on every dataset.